### PR TITLE
Cleaning up the contributors widget to not look completely ugly

### DIFF
--- a/_includes/github-contributors.html
+++ b/_includes/github-contributors.html
@@ -1,16 +1,18 @@
-<div class="card contributors d-none d-md-block float-{{ include.position | default: "left"}}">
+<div class="card contributors d-none d-md-flex flex-fill float-{{ include.position | default: "left"}}">
   <div class="card-header">
     {{ include.title | default: "Contributors to this website"}}
   </div>
-  <ul class="list-unstyled list-group list-group-flush">
-  {% for contributor in site.github.contributors %}
-    <li class="media">
-      <img class="rounded m-2" src="{{ contributor.avatar_url }}" alt="{{ contributor.login }} avatar image">
-      <div class="media-body">
-        <h5 class="mt-3 mb-1"><a href="{{ contributor.html_url }}" >{{ contributor.login }}</a></h5>
-        <a href="{{ site.github.repository_url }}/commits?author={{ contributor.login }}" >{{ contributor.contributions }} commits</a>
-      </div>
-    </li>
-  {% endfor %}
-  </ul>
+  <div class="card-body">
+    <ul class="list-unstyled list-group list-group-flush">
+      {% for contributor in site.github.contributors %}
+      <li class="media">
+        <img class="rounded m-2" src="{{ contributor.avatar_url }}" alt="{{ contributor.login }} avatar image">
+        <div class="media-body">
+          <h5 class="mt-3 mb-1"><a href="{{ contributor.html_url }}" >{{ contributor.login }}</a></h5>
+          <a href="{{ site.github.repository_url }}/commits?author={{ contributor.login }}" >{{ contributor.contributions }} commits</a>
+        </div>
+      </li>
+    {% endfor %}
+    </ul>
+  </div>
 </div>

--- a/_sass/_global.scss
+++ b/_sass/_global.scss
@@ -254,6 +254,13 @@ ul.social-buttons {
 }
 
 .card.contributors {
+  max-height: 18rem;
+
+  .card-body {
+    padding: 0;
+    overflow-y: auto;
+  }
+
   .media {
     img {
       max-width: 64px;


### PR DESCRIPTION
Making the contributors widget scroll-able, instead of letting it just fall off the bottom of the page.

![widget](https://user-images.githubusercontent.com/2442215/63218534-b3275f80-c12a-11e9-9426-7c247a796a6c.png)

closes #46 